### PR TITLE
[CI] Update CI runner from Ubuntu 18.04 to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ on:
 jobs:
   test:
     name: Testing UseLatexMk
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checking out the UseLatexMk repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Run test suite
       run: |


### PR DESCRIPTION
Use actions/checkout@v4 instead of v2